### PR TITLE
Adding CA Trust store pitfall along with further network/certificate …

### DIFF
--- a/troubleshooting-connection-issues-to-temporal-cloud.md
+++ b/troubleshooting-connection-issues-to-temporal-cloud.md
@@ -18,7 +18,7 @@
   
    Or, to test a gRPC request directly, you can use `grpcurl` (appending the same above flags if network debugging required):
 
-   `GRPC_GO_LOG_SEVERITY_LEVEL=info GRPC_GO_LOG_VERBOSITY_LEVEL=99 grpcurl -cert /path/to/client.pem -key /path/to/client.key <namespace>.<account>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo
+   `GRPC_GO_LOG_SEVERITY_LEVEL=info GRPC_GO_LOG_VERBOSITY_LEVEL=99 grpcurl -cert /path/to/client.pem -key /path/to/client.key <namespace>.<account>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo`
 
    If you can connect this way, but there are connectivity issues when running code, the problem could be in your code.
    We should suggest you test if you can connect by running one of our connectivity samples:

--- a/troubleshooting-connection-issues-to-temporal-cloud.md
+++ b/troubleshooting-connection-issues-to-temporal-cloud.md
@@ -14,9 +14,9 @@
 
    `GRPC_GO_LOG_SEVERITY_LEVEL=info GRPC_GO_LOG_VERBOSITY_LEVEL=99 temporal workflow list --address <namespace>.<accountId>.tmprl.cloud:7233 --namespace <namespace>.<accountId> --tls-cert-path ./client.pem --tls-key-path ./client.key`
 
-   - Appending the `GRPC_GO_LOG_SEVERITY_LEVEL` and `GRPC_GO_LOG_VERBOSITY_LEVEL` flags tells the Temporal CLI to trace its network calls, allowing for greater debugging visibility.
+   - Prepending the `GRPC_GO_LOG_SEVERITY_LEVEL` and `GRPC_GO_LOG_VERBOSITY_LEVEL` flags tells the Temporal CLI to trace its network calls, allowing for greater debugging visibility.
   
-   Or, to test a gRPC request directly, you can use `grpcurl` (appending the same `GRPC_GO_*` flags for network debugging):
+   Or, to test a gRPC request directly, you can use `grpcurl` (Prepending the same `GRPC_GO_*` flags for network debugging):
 
    `grpcurl -cert /path/to/client.pem -key /path/to/client.key <namespace>.<account>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo`
 

--- a/troubleshooting-connection-issues-to-temporal-cloud.md
+++ b/troubleshooting-connection-issues-to-temporal-cloud.md
@@ -16,9 +16,12 @@
 
    - Prepending the `GRPC_GO_LOG_SEVERITY_LEVEL` and `GRPC_GO_LOG_VERBOSITY_LEVEL` flags tells the Temporal CLI to trace its network calls, allowing for greater debugging visibility.
   
-   Or, to test a gRPC request directly, you can use `grpcurl` (Prepending the same `GRPC_GO_*` flags for network debugging):
+   Or, to test a gRPC request directly, you can use `grpcurl` using either mTLS, or API key authentication (Prepending the same `GRPC_GO_*` flags for network debugging):
 
-   `grpcurl -cert /path/to/client.pem -key /path/to/client.key <namespace>.<account>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo`
+   `grpcurl -cert /path/to/client.pem -key /path/to/client.key <namespace>.<accountId>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo`
+
+   `grpcurl -H "authorization: Bearer <api_key>" -H "temporal-namespace: <namespace>.<accountId>" <namespace>.<accountId>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo`
+
 
    If you can connect this way, but there are connectivity issues when running code, the problem could be in your code.
    We should suggest you test if you can connect by running one of our connectivity samples:

--- a/troubleshooting-connection-issues-to-temporal-cloud.md
+++ b/troubleshooting-connection-issues-to-temporal-cloud.md
@@ -16,7 +16,7 @@
 
    - Prepending the `GRPC_GO_LOG_SEVERITY_LEVEL` and `GRPC_GO_LOG_VERBOSITY_LEVEL` flags tells the Temporal CLI to trace its network calls, allowing for greater debugging visibility.
   
-   Or, to test a gRPC request directly, you can use `grpcurl` using either mTLS, or API key authentication (Prepending the same `GRPC_GO_*` flags for network debugging):
+   If the `temporal` CLI isn't available, you can use `grpcurl` using either mTLS, or API key authentication (Prepending the same `GRPC_GO_*` flags for network debugging):
 
    `grpcurl -cert /path/to/client.pem -key /path/to/client.key <namespace>.<accountId>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo`
 

--- a/troubleshooting-connection-issues-to-temporal-cloud.md
+++ b/troubleshooting-connection-issues-to-temporal-cloud.md
@@ -5,14 +5,20 @@
 
 1. Verify that you can reach the namespace on port 7233
 
-   `nc -zvw10 ${namespace}.tmprl.cloud 7233`
+   `nc -zvw10 <namespace>.<accountId>.tmprl.cloud 7233`
 
    If you cannot connect, your firewall or something may be blocking port 7233.
    We suggest you review it.
 
-2. If you can run the previous command successfully, please verify if you can connect to the namespace using the [temporal cli](https://docs.temporal.io/cli) and your client certificates.
+3. If you can run the previous command successfully, please verify if you can connect to the namespace using the [temporal cli](https://docs.temporal.io/cli) and your client certificates.
 
-   `temporal workflow list --address ${namespace}.tmprl.cloud:7233 --namespace ${namespace} --tls-cert-path ${client.pem} --tls-key-path ${client.key}`
+   `GRPC_GO_LOG_SEVERITY_LEVEL=info GRPC_GO_LOG_VERBOSITY_LEVEL=99 temporal workflow list --address <namespace>.<accountId>.tmprl.cloud:7233 --namespace <namespace>.<accountId> --tls-cert-path ./client.pem --tls-key-path ./client.key`
+
+   - Appending the `GRPC_GO_LOG_SEVERITY_LEVEL` and `GRPC_GO_LOG_VERBOSITY_LEVEL` flags tells the Temporal CLI to trace its network calls, allowing for greater debugging visibility.
+  
+   Or, to test a gRPC request directly, you can use `grpcurl` (appending the same above flags if network debugging required):
+
+   `GRPC_GO_LOG_SEVERITY_LEVEL=info GRPC_GO_LOG_VERBOSITY_LEVEL=99 grpcurl -cert /path/to/client.pem -key /path/to/client.key <namespace>.<account>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo
 
    If you can connect this way, but there are connectivity issues when running code, the problem could be in your code.
    We should suggest you test if you can connect by running one of our connectivity samples:
@@ -23,6 +29,13 @@
    - [Python Sample](https://github.com/temporalio/samples-python/blob/main/hello/hello_mtls.py)
    - [PHP Sample](https://www.notion.so/Client-Code-to-connect-to-Cloud-6f0ab61d8a9048d28f9023d669168634?pvs=21)
 
+  Another point to take note of, is that OpenSSL uses a different certificate store to the host OS - so it is possible that the same certs failing via SDK might succeed via the above OpenSSL command. 
+  
+  If this is the case, first validate that both the SDK and OpenSSL are actually the using the same files with `md5sum <file>` on both separately. If the hash matches, next steps can vary depending on OS/platform, but you'll need to add them to the system trust store of the Worker or wherever your code is running:
+
+   - [Redhat - The System-Wide Truststore](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/securing_networks/using-shared-system-certificates_securing-networks#the-system-wide-trust-store_using-shared-system-certificates)
+   - [Ubuntu - Install a Root CA Certificate in the Trust Store](https://ubuntu.com/server/docs/how-to/security/install-a-root-ca-certificate-in-the-trust-store/)
+     
 3. If you get the following error `invalid peer certificate: UnknownIssuer`, this is a common error when trying to connect to Temporal Cloud from typescript within a docker image.
 
    - Please verify that the docker image has the package ca-certificates installed
@@ -32,7 +45,7 @@
 
    Please run this command to verify if the CA in the namespace is working with the client certificate you are using.
 
-   `openssl s_client -connect ${namespace}.tmprl.cloud:7233 -showcerts -cert ./client.pem -key ./client.key -tls1_2 -servername ${namespace}.tmprl.cloud`
+   `openssl s_client -connect <namespace>.<accountId>.tmprl.cloud:7233 -showcerts -cert ./client.pem -key ./client.key -tls1_2 -servername <namespace>.<accountId>.tmprl.cloud`
 
    - If you see:
 

--- a/troubleshooting-connection-issues-to-temporal-cloud.md
+++ b/troubleshooting-connection-issues-to-temporal-cloud.md
@@ -16,9 +16,9 @@
 
    - Appending the `GRPC_GO_LOG_SEVERITY_LEVEL` and `GRPC_GO_LOG_VERBOSITY_LEVEL` flags tells the Temporal CLI to trace its network calls, allowing for greater debugging visibility.
   
-   Or, to test a gRPC request directly, you can use `grpcurl` (appending the same above flags if network debugging required):
+   Or, to test a gRPC request directly, you can use `grpcurl` (appending the same `GRPC_GO_*` flags for network debugging):
 
-   `GRPC_GO_LOG_SEVERITY_LEVEL=info GRPC_GO_LOG_VERBOSITY_LEVEL=99 grpcurl -cert /path/to/client.pem -key /path/to/client.key <namespace>.<account>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo`
+   `grpcurl -cert /path/to/client.pem -key /path/to/client.key <namespace>.<account>.tmprl.cloud:7233 temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo`
 
    If you can connect this way, but there are connectivity issues when running code, the problem could be in your code.
    We should suggest you test if you can connect by running one of our connectivity samples:


### PR DESCRIPTION
Outside of the actual content I made some opinionated aesthetic changes - e.g I changed instances of `${namespace}` to `<namespace>.<accountId>` because I have seen people forget this detail in the wild.

`${client.pem|key}` changed to match later example in doc using file paths.

If anything doesn't fit, feel free to send back and I'll edit it.

